### PR TITLE
Use clang from environment for deployed compiler

### DIFF
--- a/sycl/test/on-device/lit.cfg.py
+++ b/sycl/test/on-device/lit.cfg.py
@@ -35,7 +35,7 @@ config.test_source_root = os.path.dirname(__file__)
 # test_exec_root: The root path where tests should be run.
 config.test_exec_root = os.path.join(config.sycl_obj_root, 'test')
 
-llvm_config.use_clang()
+llvm_config.use_clang(use_installed=True)
 
 # Propagate some variables from the host environment.
 llvm_config.with_system_environment(['PATH', 'OCL_ICD_FILENAMES', 'SYCL_DEVICE_ALLOWLIST', 'SYCL_CONFIG_FILE_NAME'])


### PR DESCRIPTION
    When in-tree LIT tests are run on deployed compiler environment
    should be used to find clang. The patch reverts default behavior
    change done in the scope of https://reviews.llvm.org/D102630.